### PR TITLE
add empty source

### DIFF
--- a/docs/contributing/sources-and-providers.md
+++ b/docs/contributing/sources-and-providers.md
@@ -25,6 +25,7 @@ All sources live in package `source`.
 * `FakeSource`: returns a random list of Endpoints for the purpose of testing providers without having access to a Kubernetes cluster.
 * `ConnectorSource`: returns a list of Endpoint objects which are served by a tcp server configured through `connector-source-server` flag.
 * `CRDSource`: returns a list of Endpoint objects sourced from the spec of CRD objects. For more details refer to [CRD source](../crd-source.md) documentation.
+* `Empty`: returns an empty list of Endpoint objects for the purpose of testing and cleaning out entries.
 
 ### Providers
 

--- a/docs/contributing/sources-and-providers.md
+++ b/docs/contributing/sources-and-providers.md
@@ -25,7 +25,7 @@ All sources live in package `source`.
 * `FakeSource`: returns a random list of Endpoints for the purpose of testing providers without having access to a Kubernetes cluster.
 * `ConnectorSource`: returns a list of Endpoint objects which are served by a tcp server configured through `connector-source-server` flag.
 * `CRDSource`: returns a list of Endpoint objects sourced from the spec of CRD objects. For more details refer to [CRD source](../crd-source.md) documentation.
-* `Empty`: returns an empty list of Endpoint objects for the purpose of testing and cleaning out entries.
+* `EmptySource`: returns an empty list of Endpoint objects for the purpose of testing and cleaning out entries.
 
 ### Providers
 

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -222,7 +222,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("istio-ingress-gateway", "The fully-qualified name of the Istio ingress gateway service (default: istio-system/istio-ingressgateway)").Default(defaultConfig.IstioIngressGateway).StringVar(&cfg.IstioIngressGateway)
 
 	// Flags related to processing sources
-	app.Flag("source", "The resource types that are queried for endpoints; specify multiple times for multiple sources (required, options: service, ingress, fake, connector, istio-gateway, crd").Required().PlaceHolder("source").EnumsVar(&cfg.Sources, "service", "ingress", "istio-gateway", "fake", "connector", "crd")
+	app.Flag("source", "The resource types that are queried for endpoints; specify multiple times for multiple sources (required, options: service, ingress, fake, connector, istio-gateway, crd, empty").Required().PlaceHolder("source").EnumsVar(&cfg.Sources, "service", "ingress", "istio-gateway", "fake", "connector", "crd", "empty")
 	app.Flag("namespace", "Limit sources of endpoints to a specific namespace (default: all namespaces)").Default(defaultConfig.Namespace).StringVar(&cfg.Namespace)
 	app.Flag("annotation-filter", "Filter sources managed by external-dns via annotation using label selector semantics (default: all sources)").Default(defaultConfig.AnnotationFilter).StringVar(&cfg.AnnotationFilter)
 	app.Flag("fqdn-template", "A templated string that's used to generate DNS names from sources that don't define a hostname themselves, or to add a hostname suffix when paired with the fake source (optional). Accepts comma separated list for multiple global FQDN.").Default(defaultConfig.FQDNTemplate).StringVar(&cfg.FQDNTemplate)

--- a/source/empty.go
+++ b/source/empty.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/empty.go
+++ b/source/empty.go
@@ -26,7 +26,7 @@ func (e *emptySource) Endpoints() ([]*endpoint.Endpoint, error) {
 	return []*endpoint.Endpoint{}, nil
 }
 
-// NewEmpty creates a new emptySource.
-func NewEmpty() Source {
+// NewEmptySource creates a new emptySource.
+func NewEmptySource() Source {
 	return &emptySource{}
 }

--- a/source/empty.go
+++ b/source/empty.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import "github.com/kubernetes-incubator/external-dns/endpoint"
+
+// emptySource is a Source that returns no endpoints.
+type emptySource struct{}
+
+// Endpoints collects endpoints of all nested Sources and returns them in a single slice.
+func (e *emptySource) Endpoints() ([]*endpoint.Endpoint, error) {
+	return []*endpoint.Endpoint{}, nil
+}
+
+// NewEmpty creates a new emptySource.
+func NewEmpty() Source {
+	return &emptySource{}
+}

--- a/source/empty_test.go
+++ b/source/empty_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/empty_test.go
+++ b/source/empty_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 )
 
-func TestEmptyReturnsEmpty(t *testing.T) {
-	e := NewEmpty()
+func TestEmptySourceReturnsEmpty(t *testing.T) {
+	e := NewEmptySource()
 
 	endpoints, err := e.Endpoints()
 	if err != nil {

--- a/source/empty_test.go
+++ b/source/empty_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"testing"
+)
+
+func TestEmptyReturnsEmpty(t *testing.T) {
+	e := NewEmpty()
+
+	endpoints, err := e.Endpoints()
+	if err != nil {
+		t.Errorf("Expected no error but got %s", err.Error())
+	}
+
+	count := len(endpoints)
+	if count != 0 {
+		t.Errorf("Expected 0 endpoints but got %d", count)
+	}
+}


### PR DESCRIPTION
Create an empty source to help clean up records when a cluster has died.